### PR TITLE
#141392693 New dashboard tab for failed jobs.

### DIFF
--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -40,4 +40,5 @@ urlpatterns = [
     url(r'^about/$', views.about, name="hc-about"),
     url(r'^privacy/$', views.privacy, name="hc-privacy"),
     url(r'^terms/$', views.terms, name="hc-terms"),
+    url(r'^reports/$', views.reports, name="hc-reports"),
 ]

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -107,10 +107,8 @@ def docs(request):
 @login_required
 def reports(request):
     checks = Check.objects.filter(user=request.team.user).order_by("created")
-    failed_checks = []
-    for check in checks:
-        if check.get_status() == "down" and check.n_pings:
-            failed_checks.append(check)
+    failed_checks = [check for check in checks
+                     if check.get_status() == "down" and check.n_pings]
     ctx = {
         "page": "reports",
         "checks": failed_checks,

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -104,6 +104,23 @@ def docs(request):
     return render(request, "front/docs.html", ctx)
 
 
+@login_required
+def reports(request):
+    checks = Check.objects.filter(user=request.team.user).order_by("created")
+    failed_checks = []
+    for check in checks:
+        if check.get_status() == "down" and check.n_pings:
+            failed_checks.append(check)
+    ctx = {
+        "page": "reports",
+        "checks": failed_checks,
+        "now": timezone.now(),
+        "ping_endpoint": settings.PING_ENDPOINT
+    }
+
+    return render(request, "front/reports.html", ctx)
+
+
 def docs_api(request):
     ctx = {
         "page": "docs",

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,10 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'reports' %} class="active" {% endif %}>
+                        <a href="{% url 'hc-reports' %}">Failed Jobs</a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/front/reports.html
+++ b/templates/front/reports.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}Failed Jobs - healthchecks.io{% endblock %}
+
+{% block content %}
+
+
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Failed Jobs
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+    <table id="failed-checks-table" class="table hidden-xs">
+        <tr>
+            <th>Status</th>
+            <th>Name</th>
+            <th>Ping URL</th>
+            <th>Last Ping</th>
+        </tr>
+        {% for check in checks %}
+        <tr>
+          <td>
+              <span class="label label-danger">DOWN</span>
+          </td>
+            <td>{{check.name}}</td>
+            <td>{{check.url}}</td>
+            <td>{{ check.last_ping }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% else %}
+    <div class="alert alert-info"> You don't have failed checks yet.</div>
+    {% endif %}
+    </div>
+</div>
+
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}


### PR DESCRIPTION
**What does this PR do?**

 Adds a new dashboard tab for failed jobs


**Description of Task to be completed?**

Apart from the email notifications, the user  also has a separate dashboard view of their failed jobs.


**How should this be manually tested?**

- Logging into healthchecks.
- Add checks.
- Set the period(s) and grace time(s). 
- Ping checks by copy and pating them to a new browser tab.
- Wait for the set period(s) and grace time(s) to elapse.
- Navigate to failed jobs tab, and all failed jobs should appear there. 


**What are the relevant pivotal tracker stories?**


#141392693


#### Screenshots (if appropriate)

![healthchecks_bau_dashboard](https://i.imgur.com/72umJ93.png)